### PR TITLE
Ice Tray fix

### DIFF
--- a/items/Fusions.lua
+++ b/items/Fusions.lua
@@ -768,7 +768,7 @@ SMODS.Joker {
 	calculate = function(self, card, context)
 		if context.joker_main then
 			return {
-				x_mult = math.min(1, card.ability.extra.xmult * (G.GAME.starting_params.play_limit - #G.play.cards))
+				x_mult = math.max(1, card.ability.extra.xmult * (G.GAME.starting_params.play_limit - #G.play.cards))
 			}
 		end
 	end


### PR DESCRIPTION
You want `math.max` to set a minimum, not `math.min`. This is unintuitive, by which I mean it's plainly obvious why it works that way but wow does my brain latch on to the incorrect interpretation and just not let go